### PR TITLE
Enhance Access Denied page with full country names, dark mode, and mobile support

### DIFF
--- a/geoblockban.html
+++ b/geoblockban.html
@@ -1,43 +1,201 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Access Denied</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            background-color: #f4f4f4;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            height: 100vh;
-            margin: 0;
-        }
-        .ban-container {
-            background-color: white;
-            padding: 2rem;
-            border-radius: 8px;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-            max-width: 500px;
-            text-align: center;
-        }
-        .ban-title {
-            color: #dc3545;
-            margin-bottom: 1rem;
-        }
-        .ban-message {
-            color: #333;
-            line-height: 1.6;
-        }
-    </style>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Access Denied</title>
+  <style>
+    :root{
+      --bg:#f6f7f9;
+      --card:#ffffff;
+      --text:#111827;
+      --muted:#6b7280;
+      --accent:#dc3545;
+      --shadow:0 10px 25px rgba(0,0,0,.08);
+      --radius:14px;
+    }
+    @media (prefers-color-scheme: dark){
+      :root{
+        --bg:#0b0f14;
+        --card:#0f141b;
+        --text:#e5e7eb;
+        --muted:#9aa4b2;
+        --accent:#ef4444;
+        --shadow:0 10px 25px rgba(0,0,0,.35);
+      }
+    }
+    *{box-sizing:border-box}
+    html,body{height:100%}
+    body{
+      margin:0;
+      font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+      background:var(--bg);
+      color:var(--text);
+      min-height:100dvh;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      padding:24px;
+    }
+    .ban{
+      width:min(680px, 100%);
+      background:var(--card);
+      border-radius:var(--radius);
+      box-shadow:var(--shadow);
+      padding:clamp(20px, 4vw, 40px);
+      text-align:center;
+      margin:auto;
+    }
+    .ban h1{
+      margin:0 0 .5rem 0;
+      font-size:clamp(1.4rem, 4.5vw, 2rem);
+      line-height:1.2;
+      color:var(--accent);
+      letter-spacing:.2px;
+    }
+    .ban p{
+      margin:.25rem 0 0 0;
+      font-size:clamp(.95rem, 2.8vw, 1.05rem);
+      line-height:1.6;
+      color:var(--text);
+    }
+    .muted{color:var(--muted)}
+    .row{
+      display:flex; gap:.5rem; flex-wrap:wrap; justify-content:center; align-items:center;
+    }
+    .pill{
+      display:inline-flex; align-items:center; gap:.5rem;
+      padding:.4rem .7rem;
+      border-radius:999px;
+      background:rgba(127,127,127,.08);
+      font-size:.95rem;
+      white-space:nowrap;
+    }
+    .flag{font-size:1.15em; line-height:1;}
+    .hint{margin-top:1rem; font-size:.9rem;}
+  </style>
 </head>
 <body>
-    <div class="ban-container">
-        <h1 class="ban-title">Access Denied</h1>
-        <p class="ban-message">
-            Access to this website is not available in {{.Country}} [{{.IP}}]
-        </p>
-    </div>
+  <!-- Raw values from geoblock ip plugin -->
+  <div id="data" data-country="{{.Country}}" data-ip="{{.IP}}" hidden></div>
+
+  <main class="ban" role="main" aria-labelledby="title">
+    <h1 id="title">Access Denied</h1>
+
+    <p id="message">
+      Access to this website is not available in
+      <span id="countryFull" class="pill">
+        <span class="flag" id="flag" aria-hidden="true">🏳️</span>
+        <span id="countryName">—</span>
+      </span>
+    </p>
+
+    <p class="hint muted">
+      <span class="row">
+        <span id="code" class="pill" title="Country code">CC</span>
+        <span id="ip" class="pill" title="Your IP">0.0.0.0</span>
+      </span>
+    </p>
+  </main>
+
+  <script>
+    (function () {
+      const el = document.getElementById('data');
+      const rawCode = (el.getAttribute('data-country') || '').trim().toUpperCase();
+      const ip = (el.getAttribute('data-ip') || '').trim();
+
+      const codeEl = document.getElementById('code');
+      const ipEl = document.getElementById('ip');
+      const nameEl = document.getElementById('countryName');
+      const flagEl = document.getElementById('flag');
+
+      codeEl.textContent = rawCode || 'Unknown';
+      ipEl.textContent = ip || 'Unknown';
+
+      // ISO 3166-1 alpha-2 fallback map
+      const ISO_MAP = {
+        AD:"Andorra", AE:"United Arab Emirates", AF:"Afghanistan", AG:"Antigua and Barbuda", AI:"Anguilla",
+        AL:"Albania", AM:"Armenia", AO:"Angola", AQ:"Antarctica", AR:"Argentina", AS:"American Samoa",
+        AT:"Austria", AU:"Australia", AW:"Aruba", AX:"Åland Islands", AZ:"Azerbaijan",
+        BA:"Bosnia and Herzegovina", BB:"Barbados", BD:"Bangladesh", BE:"Belgium", BF:"Burkina Faso",
+        BG:"Bulgaria", BH:"Bahrain", BI:"Burundi", BJ:"Benin", BL:"Saint Barthélemy", BM:"Bermuda",
+        BN:"Brunei Darussalam", BO:"Bolivia", BQ:"Bonaire, Sint Eustatius and Saba", BR:"Brazil",
+        BS:"Bahamas", BT:"Bhutan", BV:"Bouvet Island", BW:"Botswana", BY:"Belarus", BZ:"Belize",
+        CA:"Canada", CC:"Cocos (Keeling) Islands", CD:"Congo, Democratic Republic of the", CF:"Central African Republic",
+        CG:"Congo", CH:"Switzerland", CI:"Côte d’Ivoire", CK:"Cook Islands", CL:"Chile", CM:"Cameroon",
+        CN:"China", CO:"Colombia", CR:"Costa Rica", CU:"Cuba", CV:"Cabo Verde", CW:"Curaçao", CX:"Christmas Island",
+        CY:"Cyprus", CZ:"Czechia",
+        DE:"Germany", DJ:"Djibouti", DK:"Denmark", DM:"Dominica", DO:"Dominican Republic", DZ:"Algeria",
+        EC:"Ecuador", EE:"Estonia", EG:"Egypt", EH:"Western Sahara", ER:"Eritrea", ES:"Spain", ET:"Ethiopia",
+        FI:"Finland", FJ:"Fiji", FK:"Falkland Islands (Malvinas)", FM:"Micronesia, Federated States of",
+        FO:"Faroe Islands", FR:"France",
+        GA:"Gabon", GB:"United Kingdom", GD:"Grenada", GE:"Georgia", GF:"French Guiana", GG:"Guernsey",
+        GH:"Ghana", GI:"Gibraltar", GL:"Greenland", GM:"Gambia", GN:"Guinea", GP:"Guadeloupe", GQ:"Equatorial Guinea",
+        GR:"Greece", GS:"South Georgia and the South Sandwich Islands", GT:"Guatemala", GU:"Guam",
+        GW:"Guinea-Bissau", GY:"Guyana",
+        HK:"Hong Kong", HM:"Heard Island and McDonald Islands", HN:"Honduras", HR:"Croatia", HT:"Haiti",
+        HU:"Hungary",
+        ID:"Indonesia", IE:"Ireland", IL:"Israel", IM:"Isle of Man", IN:"India", IO:"British Indian Ocean Territory",
+        IQ:"Iraq", IR:"Iran, Islamic Republic of", IS:"Iceland", IT:"Italy",
+        JE:"Jersey", JM:"Jamaica", JO:"Jordan", JP:"Japan",
+        KE:"Kenya", KG:"Kyrgyzstan", KH:"Cambodia", KI:"Kiribati", KM:"Comoros", KN:"Saint Kitts and Nevis",
+        KP:"Korea, Democratic People’s Republic of", KR:"Korea, Republic of", KW:"Kuwait", KY:"Cayman Islands",
+        KZ:"Kazakhstan", LA:"Lao People’s Democratic Republic", LB:"Lebanon", LC:"Saint Lucia", LI:"Liechtenstein",
+        LK:"Sri Lanka", LR:"Liberia", LS:"Lesotho", LT:"Lithuania", LU:"Luxembourg", LV:"Latvia", LY:"Libya",
+        MA:"Morocco", MC:"Monaco", MD:"Moldova, Republic of", ME:"Montenegro", MF:"Saint Martin (French part)",
+        MG:"Madagascar", MH:"Marshall Islands", MK:"North Macedonia", ML:"Mali", MM:"Myanmar", MN:"Mongolia",
+        MO:"Macao", MP:"Northern Mariana Islands", MQ:"Martinique", MR:"Mauritania", MS:"Montserrat",
+        MT:"Malta", MU:"Mauritius", MV:"Maldives", MW:"Malawi", MX:"Mexico", MY:"Malaysia", MZ:"Mozambique",
+        NA:"Namibia", NC:"New Caledonia", NE:"Niger", NF:"Norfolk Island", NG:"Nigeria", NI:"Nicaragua",
+        NL:"Netherlands", NO:"Norway", NP:"Nepal", NR:"Nauru", NU:"Niue", NZ:"New Zealand",
+        OM:"Oman",
+        PA:"Panama", PE:"Peru", PF:"French Polynesia", PG:"Papua New Guinea", PH:"Philippines", PK:"Pakistan",
+        PL:"Poland", PM:"Saint Pierre and Miquelon", PN:"Pitcairn", PR:"Puerto Rico", PS:"Palestine, State of",
+        PT:"Portugal", PW:"Palau", PY:"Paraguay",
+        QA:"Qatar",
+        RE:"Réunion", RO:"Romania", RS:"Serbia", RU:"Russian Federation", RW:"Rwanda",
+        SA:"Saudi Arabia", SB:"Solomon Islands", SC:"Seychelles", SD:"Sudan", SE:"Sweden", SG:"Singapore",
+        SH:"Saint Helena, Ascension and Tristan da Cunha", SI:"Slovenia", SJ:"Svalbard and Jan Mayen", SK:"Slovakia",
+        SL:"Sierra Leone", SM:"San Marino", SN:"Senegal", SO:"Somalia", SR:"Suriname", SS:"South Sudan",
+        ST:"Sao Tome and Principe", SV:"El Salvador", SX:"Sint Maarten (Dutch part)", SY:"Syrian Arab Republic",
+        SZ:"Eswatini",
+        TC:"Turks and Caicos Islands", TD:"Chad", TF:"French Southern Territories", TG:"Togo", TH:"Thailand",
+        TJ:"Tajikistan", TK:"Tokelau", TL:"Timor-Leste", TM:"Turkmenistan", TN:"Tunisia", TO:"Tonga",
+        TR:"Türkiye", TT:"Trinidad and Tobago", TV:"Tuvalu", TW:"Taiwan, Province of China",
+        TZ:"Tanzania, United Republic of",
+        UA:"Ukraine", UG:"Uganda", UM:"United States Minor Outlying Islands", US:"United States of America",
+        UY:"Uruguay", UZ:"Uzbekistan",
+        VA:"Holy See", VC:"Saint Vincent and the Grenadines", VE:"Venezuela", VG:"Virgin Islands (British)",
+        VI:"Virgin Islands (U.S.)", VN:"Viet Nam", VU:"Vanuatu",
+        WF:"Wallis and Futuna", WS:"Samoa",
+        XK:"Kosovo",
+        YE:"Yemen", YT:"Mayotte",
+        ZA:"South Africa", ZM:"Zambia", ZW:"Zimbabwe"
+      };
+
+      function countryNameFromCode(code){
+        if(!code) return 'your country';
+        if (typeof Intl !== 'undefined' && Intl.DisplayNames) {
+          try {
+            const dn = new Intl.DisplayNames([navigator.language || 'en'], { type: 'region' });
+            const name = dn.of(code);
+            if (name && name !== code) return name;
+          } catch(e){/* fallback below */}
+        }
+        return ISO_MAP[code] || 'your country';
+      }
+
+      function flagEmoji(code){
+        if(!code || code.length !== 2) return '🏳️';
+        const A = 0x1F1E6;
+        const up = code.toUpperCase();
+        return String.fromCodePoint(A + (up.codePointAt(0) - 65), A + (up.codePointAt(1) - 65));
+      }
+
+      const fullName = countryNameFromCode(rawCode);
+      document.getElementById('countryName').textContent = fullName;
+      document.getElementById('flag').textContent = flagEmoji(rawCode);
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
- Expanding the existing `{{.Country}}` two-letter code (e.g., `AU`) into the full country name (e.g., `Australia`) using the browser’s `Intl.DisplayNames` API
- Falling back gracefully if `Intl.DisplayNames` is not supported
- Preserving the existing `{{.IP}}` display for client IP information
- Making the layout fully responsive and mobile-friendly
- Adding dark mode support for better accessibility

// **Light Mode** //

<img width="2474" height="1081" alt="image" src="https://github.com/user-attachments/assets/7f19a673-1107-4cf8-a73b-2b166972476e" /><br />

// **Dark Mode** //

<img width="2491" height="1074" alt="image" src="https://github.com/user-attachments/assets/f5a37a5a-5aff-4ad1-ad55-32a4a541396b" />
